### PR TITLE
add Maven 2 vs 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target/
 *.iml
+.classpath
+.factorypath
+.project
+.settings/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mvn org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw -e -DthrowFa
 mvn org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw -e
 ```
 
-they both have the same result and output when run with Maven 3:
+they both have the same result and output when run with Maven 3 (with different Help links: http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException vs http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException):
 
 one says 
 ```shell
@@ -31,6 +31,10 @@ one says
 [INFO] Finished at: 2022-03-10T13:06:09+10:00
 [INFO] ------------------------------------------------------------------------
 [ERROR] Failed to execute goal org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw (default-cli) on project maven-exception-plugin: it's a MojoFailureException -> [Help 1]
+...
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
+
 ```
 the one says 
 ```shell
@@ -43,6 +47,9 @@ the one says
 [INFO] ------------------------------------------------------------------------
 [ERROR] Failed to execute goal org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw (default-cli) on project maven-exception-plugin: it's a MojoExecutionException -> [Help 1]
 org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw (default-cli) on project maven-exception-plugin: it's a MojoExecutionException
+...
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
 ```
 
 But with Maven 2, the difference is shown:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 MojoExecutionException vs MojoFailureException
 =
 
-there is no difference in Maven Core :) 
+there is no difference in Maven Core 3 output between results with plugin-api's
+[MojoExecutionException](https://maven.apache.org/ref/3.8.4/maven-plugin-api/apidocs/org/apache/maven/plugin/MojoExecutionException.html)
+vs [MojoFailureException ](https://maven.apache.org/ref/3.8.4/maven-plugin-api/apidocs/org/apache/maven/plugin/MojoFailureException.html):
+there was in Maven 2.
 
 just try this project. 
 Look the sources.
@@ -12,11 +15,11 @@ mvn install -Prun-its
 
 then 
 ```shell
-mvn org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw -e -DthrowFailureException=true
+mvn org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw -e -DthrowFailureException
 mvn org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw -e
 ```
 
-they both have the same result and output 
+they both have the same result and output when run with Maven 3:
 
 one says 
 ```shell
@@ -42,4 +45,39 @@ the one says
 org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw (default-cli) on project maven-exception-plugin: it's a MojoExecutionException
 ```
 
+But with Maven 2, the difference is shown:
 
+one says 
+```shell
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] Building maven-exception-plugin Maven Plugin
+[INFO]    task-segment: [org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw]
+[INFO] ------------------------------------------------------------------------
+[INFO] [exception:throw {execution: default-cli}]
+[INFO] ------------------------------------------------------------------------
+[ERROR] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] it's a MojoFailureException
+[INFO] ------------------------------------------------------------------------
+[INFO] Trace
+org.apache.maven.BuildFailureException: it's a MojoFailureException
+        at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeGoals(DefaultLifecycleExecutor.java:715)
+```
+the one says 
+```shell
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] Building maven-exception-plugin Maven Plugin
+[INFO]    task-segment: [org.apache.maven.test:maven-exception-plugin:1.0-SNAPSHOT:throw]
+[INFO] ------------------------------------------------------------------------
+[INFO] [exception:throw {execution: default-cli}]
+[INFO] ------------------------------------------------------------------------
+[ERROR] BUILD ERROR
+[INFO] ------------------------------------------------------------------------
+[INFO] it's a MojoExecutionException
+[INFO] ------------------------------------------------------------------------
+[INFO] Trace
+org.apache.maven.lifecycle.LifecycleExecutionException: it's a MojoExecutionException
+        at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeGoals(DefaultLifecycleExecutor.java:719)
+```

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>http://www.example.com</url>
 
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>2.0</maven>
   </prerequisites>
 
   <properties>


### PR DESCRIPTION
in Maven 2, FAILURE was causing a different output from ERROR
but yes, in Maven 3, this difference at runtime has been removed, but classes kept and no clear explanation about which to use (because there should be only one at the end: perhaps Maven 4 is the right time to do the cleanup)